### PR TITLE
Safeguard timeout handling in sentence setup

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { SENTENCES as defaultSentences } from './constants/sentences';
-// FIX: Import SentenceWithOptions to explicitly type the sentences array.
 import type { Word, Feedback, Assignment, StudentProgress, Result, SentenceWithOptions } from './types';
 import Header from './components/Header';
 import DropZone from './components/DropZone';
@@ -98,7 +97,6 @@ const App: React.FC = () => {
   
   // --- Core Game Logic & State Setup ---
 
-  // FIX: Explicitly type `sentences` to avoid a union type that causes issues with property access later.
   const sentences = useMemo<SentenceWithOptions[]>(
     () => assignment?.sentences ?? defaultSentences.map(s => ({ text: s })),
     [assignment]

--- a/App.tsx
+++ b/App.tsx
@@ -94,13 +94,19 @@ const App: React.FC = () => {
         clearTimeout(timeoutRef.current);
       }
     };
-  }, [setupNewSentence]);
+  }, []);
   
   // --- Core Game Logic & State Setup ---
 
   // FIX: Explicitly type `sentences` to avoid a union type that causes issues with property access later.
-  const sentences = useMemo<SentenceWithOptions[]>(() => assignment?.sentences ?? defaultSentences.map(s => ({ text: s })), [assignment]);
-  const correctSentenceText = useMemo(() => sentences[currentSentenceIndex]?.text, [sentences, currentSentenceIndex]);
+  const sentences = useMemo<SentenceWithOptions[]>(
+    () => assignment?.sentences ?? defaultSentences.map(s => ({ text: s })),
+    [assignment]
+  );
+  const correctSentenceText = useMemo(
+    () => sentences[currentSentenceIndex]?.text ?? '',
+    [sentences, currentSentenceIndex]
+  );
 
   const setupNewSentence = useCallback((index: number = currentSentenceIndex) => {
     setIsLoading(true);
@@ -123,9 +129,11 @@ const App: React.FC = () => {
 
       const seed = assignment?.seed || 'default';
       const scrambleType = assignment?.options?.scramble || 'seeded';
-      const finalWords = scrambleType === 'seeded'
-        ? seededShuffle(wordObjects, `${seed}-${index}`)
-        : wordObjects.sort(() => Math.random() - 0.5);
+      const shuffleSeed =
+        scrambleType === 'seeded'
+          ? `${seed}-${index}`
+          : `${Date.now()}-${Math.random()}`;
+      const finalWords = seededShuffle(wordObjects, shuffleSeed);
 
       if (!isMountedRef.current) return;
       setAvailableWords(finalWords);


### PR DESCRIPTION
## Summary
- track timeout and mount status with refs
- clear scheduled sentence setup on effect cleanup
- avoid state updates when component unmounts

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c512382734832c9de975c8315f20b3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Homework mode now initializes from saved progress and student name, resuming where you left off when available.
  * Practice mode starts a new session automatically with improved loading behavior.
* **Bug Fixes**
  * Improved stability by preventing state updates after leaving the page or closing the component.
  * Ensured timers are properly cancelled to avoid unexpected behavior.
* **Improvements**
  * Smoother sentence setup timing and more reliable sentence selection for a consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->