### PR TITLE
Use pako for hash compression

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react-dom": "^19.1.1",
-    "react": "^19.1.1"
+    "react": "^19.1.1",
+    "pako": "^2.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,9 @@ export default defineConfig(({ mode }) => {
         alias: {
           '@': path.resolve(__dirname, '.'),
         }
+      },
+      optimizeDeps: {
+        include: ['pako']
       }
     };
 });


### PR DESCRIPTION
## Summary
- use pako to deflate and inflate assignment data when generating URL hashes
- configure Vite to pre-bundle pako and add dependency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c51239ab44832cb7cee65d91e49f1c