### PR TITLE
Fix assignment hash parsing and base64url encoding

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -46,6 +46,10 @@ const App: React.FC = () => {
         if (loadedAssignment) {
           setAssignment(loadedAssignment);
           setMode('homework');
+        } else {
+          // Explicit fallback if parsing fails
+          setAssignment(null);
+          setMode('practice');
         }
       } else if (hash === '#teacher') {
         setMode('teacher');

--- a/utils/encoding.ts
+++ b/utils/encoding.ts
@@ -1,49 +1,47 @@
 import type { Assignment } from '../types';
-import { deflate, inflate } from 'pako';
 
-// Using pako for compression to keep URL lengths manageable.
+// --- Base64URL helpers (UTF-8 safe) ---
+const toB64Url = (json: unknown): string => {
+  const jsonString = JSON.stringify(json);
+  const b64 = btoa(unescape(encodeURIComponent(jsonString)));
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+};
 
+const fromB64Url = <T = unknown>(b64url: string): T | null => {
+  try {
+    const pad = (x: string) => x + '==='.slice((x.length + 3) % 4);
+    const b64 = pad(b64url).replace(/-/g, '+').replace(/_/g, '/');
+    const jsonString = decodeURIComponent(escape(atob(b64)));
+    return JSON.parse(jsonString) as T;
+  } catch (e) {
+    console.error('Failed to decode assignment:', e);
+    return null;
+  }
+};
+
+// Encode an Assignment object into a URL-safe hash payload.
 export const encodeAssignmentToHash = (assignment: Assignment): string => {
   try {
-    const jsonString = JSON.stringify(assignment);
-    let compressed: string;
-    try {
-      compressed = deflate(jsonString, { to: 'string' });
-    } catch (err) {
-      console.error('Compression failed', err);
-      compressed = jsonString;
-    }
-    const base64 = btoa(compressed);
-    // URL-safe Base64
-    return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    return toB64Url(assignment);
   } catch (e) {
     console.error('Encoding failed', e);
     return '';
   }
 };
 
+// Decode a hash payload back into an Assignment object.
 export const parseAssignmentFromHash = (hash: string): Assignment | null => {
-  try {
-    let base64 = hash.replace(/-/g, '+').replace(/_/g, '/');
-    while (base64.length % 4) {
-      base64 += '=';
-    }
-    const binary = atob(base64);
-    let jsonString: string;
-    try {
-      jsonString = inflate(binary, { to: 'string' });
-    } catch (err) {
-      console.error('Decompression failed', err);
-      jsonString = binary;
-    }
-    const assignment = JSON.parse(jsonString);
-    // Basic validation
-    if (assignment.id && assignment.title && Array.isArray(assignment.sentences)) {
-      return assignment as Assignment;
-    }
-    return null;
-  } catch (e) {
-    console.error('Parsing failed', e);
-    return null;
+  const obj = fromB64Url<Assignment>(hash);
+  if (!obj) return null;
+
+  // Defensive normalization of sentences
+  obj.sentences = obj.sentences.map((s: any) =>
+    typeof s === 'string' ? { text: s } : s
+  );
+
+  if (obj.id && obj.title && Array.isArray(obj.sentences)) {
+    return obj;
   }
+
+  return null;
 };


### PR DESCRIPTION
## Summary
- Robustly handle invalid assignment hashes so app falls back to practice mode
- Replace pako compression with UTF-8 safe base64url helpers for assignment links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5227ac904832cb370f6e1c754a4a1