### PR TITLE
Fix assignment link generation to preserve existing path and query

### DIFF
--- a/components/TeacherPanel.tsx
+++ b/components/TeacherPanel.tsx
@@ -39,7 +39,8 @@ const TeacherPanel: React.FC = () => {
     };
     
     const hash = encodeAssignmentToHash(assignment);
-    const link = `${window.location.origin}${window.location.pathname}#A=${hash}`;
+    const base = window.location.href.split('#')[0];
+    const link = `${base}#A=${hash}`;
     setGeneratedLink(link);
     setCopySuccess('');
   };


### PR DESCRIPTION
## Summary
- ensure generated assignment links preserve current path and query parameters by stripping only existing hash

## Testing
- `npm test`
- manual verification with Node script confirming generated link opens and decodes assignment


------
https://chatgpt.com/codex/tasks/task_e_68c5259ba868832c94abf73436637336