### PR TITLE
Fix initial sentence load and prevent progress reset re-scramble

### DIFF
--- a/components/GameApp.tsx
+++ b/components/GameApp.tsx
@@ -93,7 +93,8 @@ const GameApp: React.FC<GameAppProps> = ({ mode, assignment }) => {
     if (mode === 'practice' || (mode === 'homework' && progress)) {
       setupNewSentence(currentSentenceIndex);
     }
-  }, [currentSentenceIndex, setupNewSentence, mode, progress]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentSentenceIndex, setupNewSentence, mode]);
 
   const startNewAttempt = () => {
     if (!assignment) return;
@@ -106,6 +107,7 @@ const GameApp: React.FC<GameAppProps> = ({ mode, assignment }) => {
     };
     setProgress(initialProgress);
     setCurrentSentenceIndex(0);
+    setupNewSentence(0);
     setShowResumePrompt(false);
   };
 


### PR DESCRIPTION
## Summary
- Avoid re-scrambling sentence on progress updates by removing `progress` from effect dependencies
- Initialize first sentence on new attempt by calling `setupNewSentence(0)`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c52bef7418832c84b1474faf3bbd30