### PR TITLE
feat: support chunk-based sentence scrambling

### DIFF
--- a/components/DropZone.tsx
+++ b/components/DropZone.tsx
@@ -12,9 +12,11 @@ interface DropZoneProps {
   isDragging: boolean;
   setIsDragging: (isDragging: boolean) => void;
   isSentenceZone?: boolean;
+  startWord?: Word | null;
+  endWord?: Word | null;
 }
 
-const DropZone: React.FC<DropZoneProps> = ({ id, words, title, onDrop, onWordClick, isDragging, setIsDragging, isSentenceZone = false }) => {
+const DropZone: React.FC<DropZoneProps> = ({ id, words, title, onDrop, onWordClick, isDragging, setIsDragging, isSentenceZone = false, startWord = null, endWord = null }) => {
   const [isDragOver, setIsDragOver] = useState(false);
   const [dropIndex, setDropIndex] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -89,6 +91,9 @@ const DropZone: React.FC<DropZoneProps> = ({ id, words, title, onDrop, onWordCli
         onDragEnd={handleDragEnd}
         className={`${baseClasses} ${stateClasses} ${emptyClasses}`}
       >
+        {startWord && (
+          <WordButton word={startWord} onDragStart={handleDragStart} draggable={false} />
+        )}
         {words.length === 0 && isSentenceZone ? (
            isDragOver ? <DropIndicator /> : <span className="italic">Drop words here...</span>
         ) : (
@@ -104,6 +109,9 @@ const DropZone: React.FC<DropZoneProps> = ({ id, words, title, onDrop, onWordCli
           ))
         )}
         {isSentenceZone && isDragOver && dropIndex === words.length && words.length > 0 && <DropIndicator />}
+        {endWord && (
+          <WordButton word={endWord} onDragStart={handleDragStart} draggable={false} />
+        )}
       </div>
     </div>
   );

--- a/components/GameApp.tsx
+++ b/components/GameApp.tsx
@@ -10,6 +10,7 @@ import ResumePrompt from './ResumePrompt';
 import { tokenizeSentence } from '../utils/tokenization';
 import { seededShuffle } from '../utils/prng';
 import { saveProgress, loadProgress } from '../utils/storage';
+import { chunkSentence, needsChunking } from '../utils/chunking';
 
 const HISTORY_LIMIT = 50;
 
@@ -30,6 +31,10 @@ const GameApp: React.FC<GameAppProps> = ({ mode, assignment }) => {
   const [currentSentenceIndex, setCurrentSentenceIndex] = useState(0);
   const [availableWords, setAvailableWords] = useState<Word[]>([]);
   const [userSentence, setUserSentence] = useState<Word[]>([]);
+  const [isChunkMode, setIsChunkMode] = useState(false);
+  const [currentChunks, setCurrentChunks] = useState<string[] | null>(null);
+  const [fixedStart, setFixedStart] = useState<Word | null>(null);
+  const [fixedEnd, setFixedEnd] = useState<Word | null>(null);
   const [history, setHistory] = useState<Array<{ available: Word[]; sentence: Word[] }>>([]);
   const [feedback, setFeedback] = useState<Feedback | null>(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -75,19 +80,53 @@ const GameApp: React.FC<GameAppProps> = ({ mode, assignment }) => {
       const sentenceConf = sentences[index];
       if (!sentenceConf) return;
 
-      const words = tokenizeSentence(sentenceConf.text, sentenceConf.lock);
-      const wordObjects = words.map((text, i) => ({
-        id: `${i}-${text}`,
-        text,
-      }));
-
       const seed = assignment?.seed || 'default';
       const scrambleType = assignment?.options?.scramble || 'seeded';
-      const finalWords = scrambleType === 'seeded'
-        ? seededShuffle(wordObjects, `${seed}-${index}`)
-        : wordObjects.sort(() => Math.random() - 0.5);
 
-      setAvailableWords(finalWords);
+        let chunks: string[] | null = null;
+        if (sentenceConf.chunks && sentenceConf.chunks.length) {
+          chunks = sentenceConf.chunks;
+        } else if (needsChunking(sentenceConf.text)) {
+          chunks = chunkSentence(sentenceConf.text);
+        }
+
+        if (chunks) {
+          setIsChunkMode(true);
+          setCurrentChunks(chunks);
+
+          const wordObjects = chunks.map((text, i) => ({ id: `${i}-${text}`, text }));
+          const first = wordObjects[0];
+          const last = wordObjects[wordObjects.length - 1];
+          const middle = wordObjects.slice(1, -1);
+
+          const finalWords = scrambleType === 'seeded'
+            ? seededShuffle(middle, `${seed}-${index}`)
+            : middle.sort(() => Math.random() - 0.5);
+
+          setAvailableWords(finalWords);
+          setUserSentence([]);
+          setFixedStart(first);
+          setFixedEnd(last);
+        } else {
+          setIsChunkMode(false);
+          setCurrentChunks(null);
+          setFixedStart(null);
+          setFixedEnd(null);
+
+          const words = tokenizeSentence(sentenceConf.text, sentenceConf.lock);
+          const wordObjects = words.map((text, i) => ({
+            id: `${i}-${text}`,
+            text,
+          }));
+
+          const finalWords = scrambleType === 'seeded'
+            ? seededShuffle(wordObjects, `${seed}-${index}`)
+            : wordObjects.sort(() => Math.random() - 0.5);
+
+          setAvailableWords(finalWords);
+          setUserSentence([]);
+        }
+
       setIsLoading(false);
     }, 300);
   }, [sentences, currentSentenceIndex, assignment]);
@@ -131,14 +170,14 @@ const GameApp: React.FC<GameAppProps> = ({ mode, assignment }) => {
     return availableWords.find(w => w.id === id) || userSentence.find(w => w.id === id);
   };
 
-  const handleDrop = (wordId: string, sourceZoneId: string, targetZoneId: string, targetIndex?: number) => {
-    const wordToMove = findWordById(wordId);
-    if (!wordToMove) return;
+    const handleDrop = (wordId: string, sourceZoneId: string, targetZoneId: string, targetIndex?: number) => {
+      const wordToMove = findWordById(wordId);
+      if (!wordToMove) return;
 
-    setHistory(prev => {
-      const newHistory = [...prev, { available: [...availableWords], sentence: [...userSentence] }];
-      return newHistory.length > HISTORY_LIMIT ? newHistory.slice(1) : newHistory;
-    });
+      setHistory(prev => {
+        const newHistory = [...prev, { available: [...availableWords], sentence: [...userSentence] }];
+        return newHistory.length > HISTORY_LIMIT ? newHistory.slice(1) : newHistory;
+      });
 
     if (sourceZoneId === 'available-words' && targetZoneId === 'user-sentence') {
       setAvailableWords(prev => prev.filter(w => w.id !== wordId));
@@ -160,14 +199,14 @@ const GameApp: React.FC<GameAppProps> = ({ mode, assignment }) => {
     setIsDragging(false);
   };
 
-  const handleWordClick = (wordId: string, sourceZoneId: string) => {
-    const word = findWordById(wordId);
-    if (!word) return;
+    const handleWordClick = (wordId: string, sourceZoneId: string) => {
+      const word = findWordById(wordId);
+      if (!word) return;
 
-    setHistory(prev => {
-      const newHistory = [...prev, { available: [...availableWords], sentence: [...userSentence] }];
-      return newHistory.length > HISTORY_LIMIT ? newHistory.slice(1) : newHistory;
-    });
+      setHistory(prev => {
+        const newHistory = [...prev, { available: [...availableWords], sentence: [...userSentence] }];
+        return newHistory.length > HISTORY_LIMIT ? newHistory.slice(1) : newHistory;
+      });
     if (sourceZoneId === 'available-words') {
       setAvailableWords(prev => prev.filter(w => w.id !== wordId));
       setUserSentence(prev => [...prev, word]);
@@ -203,8 +242,20 @@ const GameApp: React.FC<GameAppProps> = ({ mode, assignment }) => {
   };
 
   const handleCheckAnswer = () => {
-    const userAnswer = userSentence.map(w => w.text).join(' ').trim();
-    const isCorrect = userAnswer === correctSentenceText;
+    let isCorrect = false;
+
+    if (isChunkMode && currentChunks) {
+      const assembled = [
+        fixedStart?.text ?? '',
+        ...userSentence.map(w => w.text),
+        fixedEnd?.text ?? ''
+      ].map(c => c.trim().toLowerCase());
+      const target = currentChunks.map(c => c.trim().toLowerCase());
+      isCorrect = assembled.join('|') === target.join('|');
+    } else {
+      const userAnswer = userSentence.map(w => w.text).join(' ').trim();
+      isCorrect = userAnswer === correctSentenceText;
+    }
 
     if (mode === 'homework') {
       updateProgress({ index: currentSentenceIndex, ok: isCorrect, revealed: false });
@@ -251,7 +302,7 @@ const GameApp: React.FC<GameAppProps> = ({ mode, assignment }) => {
       ) : (
         <div className="flex flex-col gap-6 flex-grow">
           <DropZone id="available-words" words={availableWords} title="Available Words" onDrop={(wordId, sourceZoneId) => handleDrop(wordId, sourceZoneId, 'available-words')} onWordClick={(wordId) => handleWordClick(wordId, 'available-words')} isDragging={isDragging} setIsDragging={setIsDragging} />
-          <DropZone id="user-sentence" words={userSentence} title="Your Sentence" onDrop={(wordId, sourceZoneId, index) => handleDrop(wordId, sourceZoneId, 'user-sentence', index)} onWordClick={(wordId) => handleWordClick(wordId, 'user-sentence')} isDragging={isDragging} setIsDragging={setIsDragging} isSentenceZone={true} />
+            <DropZone id="user-sentence" words={userSentence} title="Your Sentence" onDrop={(wordId, sourceZoneId, index) => handleDrop(wordId, sourceZoneId, 'user-sentence', index)} onWordClick={(wordId) => handleWordClick(wordId, 'user-sentence')} isDragging={isDragging} setIsDragging={setIsDragging} isSentenceZone={true} startWord={fixedStart} endWord={fixedEnd} />
 
           {feedback && (
             <div className={`mt-4 p-4 rounded-lg text-center font-semibold text-white ${feedback.type === 'success' ? 'bg-green-500' : 'bg-red-500'}`}>

--- a/components/WordButton.tsx
+++ b/components/WordButton.tsx
@@ -5,15 +5,16 @@ interface WordButtonProps {
   word: Word;
   onDragStart: (e: React.DragEvent<HTMLDivElement>, wordId: string) => void;
   onClick?: (wordId: string) => void;
+  draggable?: boolean;
 }
 
-const WordButton: React.FC<WordButtonProps> = ({ word, onDragStart, onClick }) => {
+const WordButton: React.FC<WordButtonProps> = ({ word, onDragStart, onClick, draggable = true }) => {
   return (
     <div
-      draggable
-      onDragStart={(e) => onDragStart(e, word.id)}
+      draggable={draggable}
+      onDragStart={draggable ? (e) => onDragStart(e, word.id) : undefined}
       onClick={() => onClick?.(word.id)}
-      className="px-4 py-2 bg-white border-2 border-gray-300 rounded-lg shadow-sm cursor-pointer cursor-grab active:cursor-grabbing hover:bg-blue-100 hover:border-blue-400 transition-all duration-150 select-none"
+      className={`px-4 py-2 bg-white border-2 border-gray-300 rounded-lg shadow-sm select-none ${draggable ? 'cursor-pointer cursor-grab active:cursor-grabbing hover:bg-blue-100 hover:border-blue-400' : 'opacity-60 cursor-default'}`}
     >
       {word.text}
     </div>

--- a/types.ts
+++ b/types.ts
@@ -14,6 +14,7 @@ export interface SentenceWithOptions {
   text: string;
   alts?: string[];
   lock?: string[];
+  chunks?: string[];
 }
 
 export interface AssignmentOptions {

--- a/utils/__tests__/chunking.test.ts
+++ b/utils/__tests__/chunking.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { chunkSentence } from '../chunking';
+
+describe('chunkSentence', () => {
+  it('splits long sentences into chunks', () => {
+    const sentence = 'For mums and dads who drop their kids off at the school gates, making friends can be just as hard in the morning.';
+    expect(chunkSentence(sentence)).toEqual([
+      'For mums and dads',
+      'who drop their kids off',
+      'at the school gates,',
+      'making friends can be just as hard',
+      'in the morning.'
+    ]);
+  });
+
+  it('processes multiple sentences separately', () => {
+    const text = 'Short one. This second sentence is considerably longer and should be split into manageable chunks, keeping things clear. Last bit.';
+    expect(chunkSentence(text)).toEqual([
+      'Short one.',
+      'This second sentence is considerably longer and should be',
+      'split into manageable chunks,',
+      'keeping things clear.',
+      'Last bit.'
+    ]);
+  });
+});
+

--- a/utils/__tests__/tokenization.test.ts
+++ b/utils/__tests__/tokenization.test.ts
@@ -23,5 +23,15 @@ describe('tokenizeSentence', () => {
       'all',
     ]);
   });
+
+  it('locks default phrasal verbs', () => {
+    expect(tokenizeSentence('We will pick up the kids')).toEqual([
+      'We',
+      'will',
+      'pick up',
+      'the',
+      'kids',
+    ]);
+  });
 });
 

--- a/utils/chunking.ts
+++ b/utils/chunking.ts
@@ -1,0 +1,108 @@
+import { tokenizeSentence } from './tokenization';
+
+// Relative pronouns that indicate a new chunk should start.
+const RELATIVE_PRONOUNS = ['who', 'that', 'which', 'where', 'when'];
+
+// Common prepositions used when enforcing maximum chunk length.
+const PREPOSITIONS = [
+  'in', 'on', 'at', 'with', 'for', 'to', 'from', 'by', 'about', 'as',
+  'into', 'like', 'through', 'after', 'over', 'between', 'out',
+  'against', 'during', 'without', 'before', 'under', 'around', 'among'
+];
+
+// Maximum number of tokens allowed in a chunk before attempting a split.
+const MAX_CHUNK_TOKENS = 8;
+
+/**
+ * Automatically chunk a sentence when the teacher does not provide explicit chunks.
+ * The algorithm loosely follows the specification provided in the project brief.
+ */
+export const chunkSentence = (text: string): string[] => {
+  const sentences = splitIntoSentences(text);
+  const result: string[] = [];
+
+  sentences.forEach(sentence => {
+    const tokens = mergeProperNouns(tokenizeSentence(sentence));
+    if (tokens.length <= 12) {
+      result.push(sentence.trim());
+      return;
+    }
+
+    let current: string[] = [];
+
+    const pushChunk = () => {
+      if (current.length) {
+        result.push(current.join(' '));
+        current = [];
+      }
+    };
+
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i];
+      const normalized = token.toLowerCase();
+
+      if (RELATIVE_PRONOUNS.includes(normalized) && current.length) {
+        pushChunk();
+      }
+
+      current.push(token);
+
+      if (current.length > MAX_CHUNK_TOKENS) {
+        const lastPrepIdx = findLastIndex(current, t => PREPOSITIONS.includes(t.toLowerCase()));
+        if (lastPrepIdx > 0) {
+          const before = current.splice(0, lastPrepIdx);
+          result.push(before.join(' '));
+          if (current.length && /[,:;]$/.test(current[current.length - 1])) {
+            pushChunk();
+          }
+        } else {
+          pushChunk();
+        }
+      }
+
+      if (/[,:;]$/.test(token)) {
+        pushChunk();
+        continue;
+      }
+    }
+
+    pushChunk();
+  });
+
+  return result;
+};
+
+export const needsChunking = (text: string): boolean => {
+  const sentences = splitIntoSentences(text);
+  return sentences.some(sentence => {
+    const tokens = mergeProperNouns(tokenizeSentence(sentence));
+    return tokens.length > 12;
+  });
+};
+
+const splitIntoSentences = (text: string): string[] => {
+  const matches = text.match(/[^.!?…]+(?:\.\.\.|[.!?…])?/g);
+  return matches ? matches.map(s => s.trim()).filter(Boolean) : [text.trim()];
+};
+
+// Merge consecutive capitalized tokens to avoid splitting proper names.
+const mergeProperNouns = (tokens: string[]): string[] => {
+  const merged: string[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (i > 0 && /^[A-Z]/.test(token) && /^[A-Z]/.test(tokens[i - 1])) {
+      merged[merged.length - 1] = merged[merged.length - 1] + ' ' + token;
+    } else {
+      merged.push(token);
+    }
+  }
+  return merged;
+};
+
+const findLastIndex = <T>(arr: T[], predicate: (t: T) => boolean): number => {
+  for (let i = arr.length - 1; i >= 0; i--) {
+    if (predicate(arr[i])) return i;
+  }
+  return -1;
+};
+

--- a/utils/tokenization.ts
+++ b/utils/tokenization.ts
@@ -4,10 +4,21 @@
  * @param lockedPhrases Optional array of phrases to keep as single tokens.
  * @returns An array of string tokens.
  */
+// Default list of phrasal verbs that should be treated as a single token.
+// This list can be extended later as needed.
+const DEFAULT_LOCKED_PHRASES = [
+  'drop off', 'pick up', 'turn on', 'turn off', 'put on', 'take off',
+  'look after', 'give up', 'run into', 'get over', 'come across',
+  'work out', 'set up', 'find out', 'figure out', 'go on', 'carry on'
+];
+
 export const tokenizeSentence = (sentence: string, lockedPhrases: string[] = []): string[] => {
+  // Merge the default phrasal verbs with any teacher-provided locked phrases.
+  const allLocked = [...DEFAULT_LOCKED_PHRASES, ...lockedPhrases];
+
   // Create a regex that matches any of the locked phrases.
   // We sort by length descending to match longer phrases first (e.g., "in spite of" before "spite of").
-  const sortedLocked = [...lockedPhrases].sort((a, b) => b.length - a.length);
+  const sortedLocked = [...allLocked].sort((a, b) => b.length - a.length);
 
   // This regex will find either a locked phrase or a sequence of non-space characters (a word).
   // It handles punctuation attached to words correctly.


### PR DESCRIPTION
## Summary
- exclude first and last chunks from answer state while locking them as immovable hints
- auto-chunk multi-sentence inputs by sentence and only chunk long sentences
- cover multi-sentence chunking with unit tests

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5b747c2dc832cbe8fc1bef929d433