### PR TITLE
Use TextEncoder/TextDecoder for UTF-8 encoding

### DIFF
--- a/utils/__tests__/encoding.test.ts
+++ b/utils/__tests__/encoding.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { encodeAssignmentToHash, parseAssignmentFromHash } from '../encoding';
+import type { Assignment } from '../../types';
+
+describe('encoding utilities', () => {
+  it('round-trip encodes and decodes Unicode strings', () => {
+    const assignment: Assignment = {
+      id: '1',
+      title: 'こんにちは世界 😀',
+      version: 1,
+      seed: 'seed',
+      options: {
+        attempts: 'unlimited',
+        hints: 'none',
+        feedback: 'show-on-wrong',
+        scramble: 'seeded',
+      },
+      sentences: [
+        { text: '🦄 Unicode テキスト' },
+      ],
+    };
+
+    const encoded = encodeAssignmentToHash(assignment);
+    const decoded = parseAssignmentFromHash(encoded);
+
+    expect(decoded).toEqual(assignment);
+  });
+});


### PR DESCRIPTION
## Summary
- replace legacy escape/unescape with `TextEncoder`/`TextDecoder` for Base64URL helpers
- add unit test ensuring Unicode strings round-trip through encode/decode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5c8999378832ca83f5aa03357bf2d