### PR TITLE
Use private-use placeholder for sentence splitting

### DIFF
--- a/utils/__tests__/sentenceSplitter.test.ts
+++ b/utils/__tests__/sentenceSplitter.test.ts
@@ -20,6 +20,14 @@ describe('splitIntoSentences', () => {
       'Mix well.'
     ]);
   });
+
+  it('preserves bullet characters in text', () => {
+    const text = 'Look for the bullet • in this sentence. Next sentence.';
+    expect(splitIntoSentences(text)).toEqual([
+      'Look for the bullet • in this sentence.',
+      'Next sentence.'
+    ]);
+  });
 });
 
 describe('parseTeacherInput', () => {

--- a/utils/sentenceSplitter.ts
+++ b/utils/sentenceSplitter.ts
@@ -5,15 +5,15 @@ export const splitIntoSentences = (text: string): string[] => {
     'U.S.', 'U.K.', 'U.N.', 'Jan.', 'Feb.', 'Mar.', 'Apr.', 'Jun.', 'Jul.',
     'Aug.', 'Sep.', 'Sept.', 'Oct.', 'Nov.', 'Dec.'
   ];
-  const placeholder = '•';
+  const placeholder = '\uF000';
   ABBREVIATIONS.forEach(abbr => {
     const escaped = abbr.replace(/\./g, '\\.');
     const repl = abbr.replace(/\./g, placeholder);
-    normalized = normalized.replace(new RegExp(escaped, 'g'), repl);
+    normalized = normalized.replace(new RegExp(escaped, 'gu'), repl);
   });
   normalized = normalized.replace(/(\d)\.(\d)/g, `$1${placeholder}$2`);
   const parts = normalized.split(/(?<=[.!?])\s+(?=(?:["“‘(]*[A-Z]))/);
-  return parts.map(p => p.replace(new RegExp(placeholder, 'g'), '.').trim()).filter(Boolean);
+  return parts.map(p => p.replace(new RegExp(placeholder, 'gu'), '.').trim()).filter(Boolean);
 };
 
 import type { SentenceWithOptions } from '../types';


### PR DESCRIPTION
## Summary
- replace bullet placeholder with private-use Unicode character
- update regex replacements to handle the new placeholder
- add tests verifying sentences with bullet characters are preserved

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5c8921958832ca7f3872591d18b3a