### PR TITLE
Fix Telegram share URL

### DIFF
--- a/components/ResultsModal.tsx
+++ b/components/ResultsModal.tsx
@@ -108,7 +108,7 @@ ID: ${assignment.id.split('-')[1]}`;
             WhatsApp
           </a>
           <a
-            href={`https://t.me/share/url?url= &text=${encodedText}`}
+            href={`https://t.me/share/url?text=${encodedText}`}
             target="_blank"
             rel="noopener noreferrer"
             className="p-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors block"


### PR DESCRIPTION
## Summary
- remove invalid Telegram share URL parameter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5cbdd2af0832c9fa1855fc916738b