### PR TITLE
Ensure non-form buttons do not submit

### DIFF
--- a/components/GameApp.tsx
+++ b/components/GameApp.tsx
@@ -350,17 +350,17 @@ const GameApp: React.FC<GameAppProps> = ({ mode, assignment }) => {
               <>
                 {mode === 'homework' && (
                   <>
-                    <button onClick={handleUndo} className="w-full sm:w-auto px-6 py-3 bg-gray-500 text-white font-bold rounded-lg shadow-md hover:bg-gray-600 transition-colors">Undo</button>
-                    <button onClick={() => setupNewSentence()} className="w-full sm:w-auto px-6 py-3 bg-yellow-500 text-white font-bold rounded-lg shadow-md hover:bg-yellow-600 transition-colors">Reset</button>
+                    <button type="button" onClick={handleUndo} className="w-full sm:w-auto px-6 py-3 bg-gray-500 text-white font-bold rounded-lg shadow-md hover:bg-gray-600 transition-colors">Undo</button>
+                    <button type="button" onClick={() => setupNewSentence()} className="w-full sm:w-auto px-6 py-3 bg-yellow-500 text-white font-bold rounded-lg shadow-md hover:bg-yellow-600 transition-colors">Reset</button>
                   </>
                 )}
-                <button onClick={handleCheckAnswer} disabled={userSentence.length === 0} className="w-full sm:w-auto px-8 py-3 bg-blue-600 text-white font-bold rounded-lg shadow-md hover:bg-blue-700 disabled:bg-gray-400 transition-all transform hover:scale-105">Check Answer</button>
+                <button type="button" onClick={handleCheckAnswer} disabled={userSentence.length === 0} className="w-full sm:w-auto px-8 py-3 bg-blue-600 text-white font-bold rounded-lg shadow-md hover:bg-blue-700 disabled:bg-gray-400 transition-all transform hover:scale-105">Check Answer</button>
                 {mode === 'homework' && (
-                  <button onClick={handleReveal} className="w-full sm:w-auto px-6 py-3 bg-red-600 text-white font-bold rounded-lg shadow-md hover:bg-red-700 transition-colors">Reveal</button>
+                  <button type="button" onClick={handleReveal} className="w-full sm:w-auto px-6 py-3 bg-red-600 text-white font-bold rounded-lg shadow-md hover:bg-red-700 transition-colors">Reveal</button>
                 )}
               </>
             ) : (
-              <button onClick={handleNext} className="w-full sm:w-auto px-8 py-3 bg-indigo-600 text-white font-bold rounded-lg shadow-md hover:bg-indigo-700 transition-all transform hover:scale-105">
+              <button type="button" onClick={handleNext} className="w-full sm:w-auto px-8 py-3 bg-indigo-600 text-white font-bold rounded-lg shadow-md hover:bg-indigo-700 transition-all transform hover:scale-105">
                 {currentSentenceIndex < sentences.length - 1 ? 'Next Sentence' : (mode === 'homework' ? 'Finish & See Results' : 'Next Sentence')}
               </button>
             )}

--- a/components/ResultsModal.tsx
+++ b/components/ResultsModal.tsx
@@ -80,6 +80,7 @@ ID: ${assignment.id.split('-')[1]}`;
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div>
             <button
+              type="button"
               onClick={copyToClipboard}
               className="p-3 bg-gray-700 text-white rounded-lg hover:bg-gray-800 transition-colors"
             >

--- a/components/ResumePrompt.tsx
+++ b/components/ResumePrompt.tsx
@@ -12,12 +12,14 @@ const ResumePrompt: React.FC<ResumePromptProps> = ({ onResume, onStartOver }) =>
       <p className="text-gray-600 mb-6">We found a previous attempt in progress. What would you like to do?</p>
       <div className="flex gap-4">
         <button
+          type="button"
           onClick={onResume}
           className="px-8 py-3 bg-blue-600 text-white font-bold rounded-lg shadow-md hover:bg-blue-700 transition-all transform hover:scale-105"
         >
           Resume
         </button>
         <button
+          type="button"
           onClick={onStartOver}
           className="px-8 py-3 bg-gray-300 text-gray-800 font-bold rounded-lg shadow-sm hover:bg-gray-400 transition-colors"
         >

--- a/components/TeacherPanel.tsx
+++ b/components/TeacherPanel.tsx
@@ -123,6 +123,7 @@ const TeacherPanel: React.FC = () => {
 
         <div className="flex justify-between items-center flex-wrap gap-4">
             <button
+                type="button"
                 onClick={generateLink}
                 className="px-6 py-2 bg-blue-600 text-white font-bold rounded-lg shadow-md hover:bg-blue-700 transition-all transform hover:scale-105"
             >
@@ -145,6 +146,7 @@ const TeacherPanel: React.FC = () => {
               onFocus={(e) => e.target.select()}
             />
             <button
+              type="button"
               onClick={copyToClipboard}
               className="mt-4 px-6 py-2 bg-green-600 text-white font-bold rounded-lg shadow-md hover:bg-green-700 transition-all"
             >


### PR DESCRIPTION
## Summary
- add explicit `type="button"` to interactive buttons in GameApp to avoid unintended form submissions
- do the same for resume prompt and results modal buttons
- update teacher panel buttons to be non-submitting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5cbdee8c8832c848ac3827037cb06