### PR TITLE
Fix TeacherPanel back navigation to practice mode

### DIFF
--- a/components/TeacherPanel.tsx
+++ b/components/TeacherPanel.tsx
@@ -128,7 +128,7 @@ const TeacherPanel: React.FC = () => {
             >
                 Generate Link
             </button>
-             <a href="#" className="px-6 py-2 bg-gray-600 text-white font-bold rounded-lg shadow-md hover:bg-gray-700 transition-all">
+             <a href="#practice" className="px-6 py-2 bg-gray-600 text-white font-bold rounded-lg shadow-md hover:bg-gray-700 transition-all">
                 Back to Practice
             </a>
         </div>


### PR DESCRIPTION
## Summary
- Replace placeholder href on "Back to Practice" with `#practice` hash so the app mode switches correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5cbe1e3e0832ca11976f0e5d2bf05