### PR TITLE
refactor: type sentence normalization

### DIFF
--- a/utils/__tests__/encoding.test.ts
+++ b/utils/__tests__/encoding.test.ts
@@ -25,4 +25,28 @@ describe('encoding utilities', () => {
 
     expect(decoded).toEqual(assignment);
   });
+
+  it('normalizes sentences provided as plain strings', () => {
+    const assignmentLike = {
+      id: '1',
+      title: 'mixed',
+      version: 1,
+      seed: 'seed',
+      options: {
+        attempts: 'unlimited',
+        hints: 'none',
+        feedback: 'show-on-wrong',
+        scramble: 'seeded',
+      },
+      sentences: ['hello', { text: 'world' }],
+    };
+
+    const encoded = encodeAssignmentToHash(assignmentLike as unknown as Assignment);
+    const decoded = parseAssignmentFromHash(encoded);
+
+    expect(decoded?.sentences).toEqual([
+      { text: 'hello' },
+      { text: 'world' },
+    ]);
+  });
 });

--- a/utils/encoding.ts
+++ b/utils/encoding.ts
@@ -1,4 +1,4 @@
-import type { Assignment } from '../types';
+import type { Assignment, SentenceWithOptions } from '../types';
 
 // --- Base64URL helpers (UTF-8 safe using TextEncoder/TextDecoder) ---
 const toB64Url = (json: unknown): string => {
@@ -38,12 +38,15 @@ export const encodeAssignmentToHash = (assignment: Assignment): string => {
 
 // Decode a hash payload back into an Assignment object.
 export const parseAssignmentFromHash = (hash: string): Assignment | null => {
-  const obj = fromB64Url<Assignment>(hash);
+  const obj = fromB64Url<
+    Assignment & { sentences: Array<string | SentenceWithOptions> }
+  >(hash);
   if (!obj) return null;
 
   // Defensive normalization of sentences
-  obj.sentences = obj.sentences.map((s: any) =>
-    typeof s === 'string' ? { text: s } : s
+  obj.sentences = obj.sentences.map(
+    (s: string | SentenceWithOptions): SentenceWithOptions =>
+      typeof s === 'string' ? { text: s } : s
   );
 
   if (obj.id && obj.title && Array.isArray(obj.sentences)) {


### PR DESCRIPTION
## Summary
- replace `any` usage when normalizing sentences with explicit `string | SentenceWithOptions` union
- add test to ensure parsing handles string sentences

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5d0ff985c832cbe21aa4f6164354a