### PR TITLE
Handle assignment IDs without dash in share text

### DIFF
--- a/components/ResultsModal.tsx
+++ b/components/ResultsModal.tsx
@@ -19,11 +19,14 @@ const ResultsModal: React.FC<ResultsModalProps> = ({ assignment, progress }) => 
       return `${r.index + 1}${status}`;
     }).join(' ');
 
+    const idParts = assignment.id.split('-');
+    const shareId = idParts.length > 1 ? idParts[1] : assignment.id;
+
     return `Homework: ${assignment.title} (v${assignment.version})
 Student: ${student.name || 'N/A'}
 Result: ${score} correct (${summary.reveals} reveals)
 Items: ${items}
-ID: ${assignment.id.split('-')[1]}`;
+ID: ${shareId}`;
   };
 
   const shareText = generateShareText();


### PR DESCRIPTION
## Summary
- Ensure share text uses full assignment ID when no dash is present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5d0fb2a98832cad615d106b2762d1