### PR TITLE
feat: add touch support for drag and drop

### DIFF
--- a/components/DropZone.tsx
+++ b/components/DropZone.tsx
@@ -159,13 +159,24 @@ const DropZone: React.FC<DropZoneProps> = ({
 
       if (within) {
         const { wordId, sourceZoneId } = touchDragData;
-        onDrop(wordId, sourceZoneId, isSentenceZone ? dropIndex ?? undefined : undefined);
+        onDrop(
+          wordId,
+          sourceZoneId,
+          isSentenceZone ? dropIndex ?? undefined : undefined,
+        );
+        setIsDragging(false);
+        touchDragData = null;
+      } else {
+        setTimeout(() => {
+          if (touchDragData) {
+            setIsDragging(false);
+            touchDragData = null;
+          }
+        }, 0);
       }
 
       setIsDragOver(false);
       setDropIndex(null);
-      setIsDragging(false);
-      touchDragData = null;
     };
 
     window.addEventListener("touchmove", handleWindowTouchMove, { passive: false });

--- a/components/WordButton.tsx
+++ b/components/WordButton.tsx
@@ -4,20 +4,29 @@ import type { Word } from "../types";
 interface WordButtonProps {
   word: Word;
   onDragStart: (e: React.DragEvent<HTMLDivElement>, wordId: string) => void;
+  onTouchStart: (e: React.TouchEvent<HTMLDivElement>, wordId: string) => void;
+  onTouchMove: (e: React.TouchEvent<HTMLDivElement>) => void;
+  onTouchEnd: (e: React.TouchEvent<HTMLDivElement>) => void;
   onClick?: (wordId: string) => void;
 }
 
 const WordButton: React.FC<WordButtonProps> = ({
   word,
   onDragStart,
+  onTouchStart,
+  onTouchMove,
+  onTouchEnd,
   onClick,
 }) => {
   return (
     <div
       draggable
       onDragStart={(e) => onDragStart(e, word.id)}
+      onTouchStart={(e) => onTouchStart(e, word.id)}
+      onTouchMove={onTouchMove}
+      onTouchEnd={onTouchEnd}
       onClick={() => onClick?.(word.id)}
-      className="px-4 py-2 bg-white border-2 border-gray-300 rounded-lg shadow-sm cursor-pointer cursor-grab active:cursor-grabbing hover:bg-blue-100 hover:border-blue-400 transition-all duration-150 select-none"
+      className="px-4 py-2 bg-white border-2 border-gray-300 rounded-lg shadow-sm cursor-pointer cursor-grab active:cursor-grabbing hover:bg-blue-100 hover:border-blue-400 transition-all duration-150 select-none touch-none"
     >
       {word.text}
     </div>


### PR DESCRIPTION
## Summary
- handle touch-based dragging in WordButton and DropZone
- compute drop index and execute drops on touch devices
- prevent page scrolling while dragging by touch

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6fcc82014832caa913fe415caadd3