### PR TITLE
feat: compute detailed results summary

### DIFF
--- a/components/GameApp.tsx
+++ b/components/GameApp.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { SENTENCES as defaultSentences } from '../constants/sentences';
 import type { Word, Feedback, Assignment, StudentProgress, Result, SentenceWithOptions } from '../types';
+import { computeSummary } from '../utils/summary';
 import Header from './Header';
 import DropZone from './DropZone';
 import SpinnerIcon from './icons/SpinnerIcon';
@@ -145,11 +146,11 @@ const GameApp: React.FC<GameAppProps> = ({ mode, assignment }) => {
 
   const startNewAttempt = () => {
     if (!assignment) return;
-    const initialProgress = {
+    const initialProgress: StudentProgress = {
       assignmentId: assignment.id,
       version: assignment.version,
       student: { name: studentName },
-      summary: { correct: 0, total: assignment.sentences.length, reveals: 0 },
+      summary: { total: assignment.sentences.length, solved: 0, firstTry: 0, reveals: 0, avgAttempts: 0 },
       results: []
     };
     setProgress(initialProgress);
@@ -277,14 +278,13 @@ const GameApp: React.FC<GameAppProps> = ({ mode, assignment }) => {
   // --- Answer Checking & Progression ---
   const updateProgress = (result: Result) => {
     if (!progress || !assignment) return;
+    const newResults = [...progress.results, result];
+    const newSummary = computeSummary(newResults);
+    newSummary.total = assignment.sentences.length;
     const newProgress: StudentProgress = {
       ...progress,
-      results: [...progress.results, result],
-      summary: {
-        ...progress.summary,
-        correct: progress.summary.correct + (result.ok ? 1 : 0),
-        reveals: progress.summary.reveals + (result.revealed ? 1 : 0)
-      }
+      results: newResults,
+      summary: newSummary
     };
     setProgress(newProgress);
     const storageKey = `ss::${assignment.id}::${studentName}`;
@@ -304,7 +304,7 @@ const GameApp: React.FC<GameAppProps> = ({ mode, assignment }) => {
     }
 
     if (mode === 'homework') {
-      updateProgress({ index: currentSentenceIndex, ok: isCorrect, revealed: false });
+      updateProgress({ index: currentSentenceIndex, ok: isCorrect, revealed: false, attempts: 1 });
     }
 
     setFeedback({
@@ -315,7 +315,7 @@ const GameApp: React.FC<GameAppProps> = ({ mode, assignment }) => {
 
   const handleReveal = () => {
     if (mode === 'homework') {
-      updateProgress({ index: currentSentenceIndex, ok: false, revealed: true });
+      updateProgress({ index: currentSentenceIndex, ok: false, revealed: true, attempts: 0 });
     }
     setFeedback({ type: 'error', message: `The correct answer is: "${correctSentenceText}"` });
   };

--- a/components/ResultsModal.tsx
+++ b/components/ResultsModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import type { Assignment, StudentProgress } from '../types';
+import { computeSummary } from '../utils/summary';
 
 interface ResultsModalProps {
   assignment: Assignment;
@@ -7,8 +8,8 @@ interface ResultsModalProps {
 }
 
 const ResultsModal: React.FC<ResultsModalProps> = ({ assignment, progress }) => {
-  const { summary, student, results } = progress;
-  const score = `${summary.correct}/${summary.total}`;
+  const { student, results } = progress;
+  const summary = computeSummary(results);
   const [copyMessage, setCopyMessage] = useState<string | null>(null);
   const [isError, setIsError] = useState(false);
 
@@ -24,7 +25,9 @@ const ResultsModal: React.FC<ResultsModalProps> = ({ assignment, progress }) => 
 
     return `Homework: ${assignment.title} (v${assignment.version})
 Student: ${student.name || 'N/A'}
-Result: ${score} correct (${summary.reveals} reveals)
+Solved: ${summary.solved} / ${summary.total}
+First-try: ${summary.firstTry} / ${summary.total} • Reveals: ${summary.reveals}
+Avg attempts (solved): ${summary.avgAttempts.toFixed(2)}
 Items: ${items}
 ID: ${shareId}`;
   };
@@ -57,12 +60,13 @@ ID: ${shareId}`;
       <p className="text-lg text-gray-700 mb-4">Here are your results for "{assignment.title}".</p>
       
       <div className="text-5xl font-bold my-4">
-        {score}
-        <span className="text-2xl font-medium text-gray-600"> correct</span>
+        Solved: {summary.solved} / {summary.total}
       </div>
-      
-      <div className="my-4 text-gray-500">
-        {summary.reveals > 0 && <span>({summary.reveals} revealed)</span>}
+      <div className="my-2 text-gray-700">
+        First-try: {summary.firstTry} / {summary.total} • Reveals: {summary.reveals}
+      </div>
+      <div className="text-sm text-gray-500 mb-4">
+        Avg attempts (solved): {summary.avgAttempts.toFixed(2)}
       </div>
 
       <div className="flex flex-wrap gap-2 justify-center my-4">

--- a/types.ts
+++ b/types.ts
@@ -37,16 +37,21 @@ export interface Result {
   index: number;
   ok: boolean;
   revealed: boolean;
+  attempts: number;
+}
+
+export interface Summary {
+  total: number;
+  solved: number;
+  firstTry: number;
+  reveals: number;
+  avgAttempts: number;
 }
 
 export interface StudentProgress {
   assignmentId: string;
   version: number;
   student: { name: string };
-  summary: {
-    correct: number;
-    total: number;
-    reveals: number;
-  };
+  summary: Summary;
   results: Result[];
 }

--- a/utils/__tests__/storage.test.ts
+++ b/utils/__tests__/storage.test.ts
@@ -8,7 +8,7 @@ describe('saveProgress', () => {
     assignmentId: 'a1',
     version: 1,
     student: { name: 'Alice' },
-    summary: { correct: 0, total: 1, reveals: 0 },
+    summary: { total: 1, solved: 0, firstTry: 0, reveals: 0, avgAttempts: 0 },
     results: []
   };
 
@@ -46,7 +46,7 @@ describe('loadProgress', () => {
     assignmentId: 'a1',
     version: 1,
     student: { name: 'Alice' },
-    summary: { correct: 0, total: 1, reveals: 0 },
+    summary: { total: 1, solved: 0, firstTry: 0, reveals: 0, avgAttempts: 0 },
     results: []
   };
 

--- a/utils/__tests__/summary.test.ts
+++ b/utils/__tests__/summary.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { computeSummary } from '../summary';
+import type { Result } from '../../types';
+
+describe('computeSummary', () => {
+  it('handles empty results', () => {
+    const summary = computeSummary([]);
+    expect(summary).toEqual({ total: 0, solved: 0, firstTry: 0, reveals: 0, avgAttempts: 0 });
+  });
+
+  it('computes statistics correctly', () => {
+    const results: Result[] = [
+      { index: 0, ok: true, revealed: false, attempts: 1 },
+      { index: 1, ok: true, revealed: false, attempts: 2 },
+      { index: 2, ok: false, revealed: true, attempts: 0 },
+    ];
+    const summary = computeSummary(results);
+    expect(summary.total).toBe(3);
+    expect(summary.solved).toBe(2);
+    expect(summary.firstTry).toBe(1);
+    expect(summary.reveals).toBe(1);
+    expect(summary.avgAttempts).toBeCloseTo(1.5);
+  });
+});

--- a/utils/__tests__/summary.test.ts
+++ b/utils/__tests__/summary.test.ts
@@ -21,4 +21,13 @@ describe('computeSummary', () => {
     expect(summary.reveals).toBe(1);
     expect(summary.avgAttempts).toBeCloseTo(1.5);
   });
+
+  it('defaults missing attempts to 1', () => {
+    const results = [
+      { index: 0, ok: true, revealed: false, attempts: 2 },
+      { index: 1, ok: true, revealed: false } as any,
+    ] as Result[];
+    const summary = computeSummary(results);
+    expect(summary.avgAttempts).toBeCloseTo(1.5);
+  });
 });

--- a/utils/summary.ts
+++ b/utils/summary.ts
@@ -7,7 +7,7 @@ export const computeSummary = (results: Result[]): Summary => {
   const firstTry = solvedResults.filter(r => r.attempts === 1).length;
   const reveals = results.filter(r => r.revealed).length;
   const avgAttempts = solved > 0
-    ? solvedResults.reduce((sum, r) => sum + r.attempts, 0) / solved
+    ? solvedResults.reduce((sum, r) => sum + (r.attempts ?? 1), 0) / solved
     : 0;
 
   return { total, solved, firstTry, reveals, avgAttempts };

--- a/utils/summary.ts
+++ b/utils/summary.ts
@@ -1,0 +1,14 @@
+import type { Result, Summary } from '../types';
+
+export const computeSummary = (results: Result[]): Summary => {
+  const total = results.length;
+  const solvedResults = results.filter(r => r.ok);
+  const solved = solvedResults.length;
+  const firstTry = solvedResults.filter(r => r.attempts === 1).length;
+  const reveals = results.filter(r => r.revealed).length;
+  const avgAttempts = solved > 0
+    ? solvedResults.reduce((sum, r) => sum + r.attempts, 0) / solved
+    : 0;
+
+  return { total, solved, firstTry, reveals, avgAttempts };
+};


### PR DESCRIPTION
## Summary
- add `computeSummary` utility to derive solved count, first-try accuracy, reveals, and average attempts from results
- display new summary lines in results modal and share text
- track attempt counts and recompute summaries as students progress

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c821d93760832c84d3e15879e2bfb4