### PR TITLE
Add attempt meter near check button

### DIFF
--- a/components/GameApp.tsx
+++ b/components/GameApp.tsx
@@ -35,6 +35,8 @@ const GameApp: React.FC<GameAppProps> = ({ mode, assignment }) => {
   const [history, setHistory] = useState<Array<{ available: Word[]; sentence: Word[] }>>([]);
   const [feedback, setFeedback] = useState<Feedback | null>(null);
   const [isDragging, setIsDragging] = useState(false);
+  const [attemptsUsed, setAttemptsUsed] = useState(0);
+  const maxAttempts = 3;
 
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -81,6 +83,7 @@ const GameApp: React.FC<GameAppProps> = ({ mode, assignment }) => {
     setIsLoading(true);
     setFeedback(null);
     setUserSentence([]);
+    setAttemptsUsed(0);
 
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
     timeoutRef.current = setTimeout(() => {
@@ -292,6 +295,7 @@ const GameApp: React.FC<GameAppProps> = ({ mode, assignment }) => {
   };
 
   const handleCheckAnswer = () => {
+    setAttemptsUsed(prev => Math.min(prev + 1, maxAttempts));
     let isCorrect = false;
 
     if (isChunkMode && currentChunks) {
@@ -365,7 +369,21 @@ const GameApp: React.FC<GameAppProps> = ({ mode, assignment }) => {
                     <button type="button" onClick={() => setupNewSentence()} className="w-full sm:w-auto px-6 py-3 bg-yellow-500 text-white font-bold rounded-lg shadow-md hover:bg-yellow-600 transition-colors">Reset</button>
                   </>
                 )}
-                <button type="button" onClick={handleCheckAnswer} disabled={userSentence.length === 0} className="w-full sm:w-auto px-8 py-3 bg-blue-600 text-white font-bold rounded-lg shadow-md hover:bg-blue-700 disabled:bg-gray-400 transition-all transform hover:scale-105">Check Answer</button>
+                <div className="flex items-center gap-2 w-full sm:w-auto justify-center">
+                  <div className="text-xl" aria-label={`Attempt ${attemptsUsed} of ${maxAttempts}`}>
+                    {Array.from({ length: maxAttempts }).map((_, i) => (
+                      <span key={i}>{i < attemptsUsed ? '●' : '○'}</span>
+                    ))}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={handleCheckAnswer}
+                    disabled={userSentence.length === 0}
+                    className="w-full sm:w-auto px-8 py-3 bg-blue-600 text-white font-bold rounded-lg shadow-md hover:bg-blue-700 disabled:bg-gray-400 transition-all transform hover:scale-105"
+                  >
+                    Check Answer
+                  </button>
+                </div>
                 {mode === 'homework' && (
                   <button type="button" onClick={handleReveal} className="w-full sm:w-auto px-6 py-3 bg-red-600 text-white font-bold rounded-lg shadow-md hover:bg-red-700 transition-colors">Reveal</button>
                 )}


### PR DESCRIPTION
## Summary
- show attempt progress meter near Check button
- track attemptsUsed state and reset per sentence
- increment attempts on Check and expose aria label for accessibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c821d81160832ca72a5fd5f06bc929